### PR TITLE
OS X compatibility

### DIFF
--- a/lib/pocketops/config.rb
+++ b/lib/pocketops/config.rb
@@ -1,3 +1,5 @@
+require 'unix_crypt'
+
 module Pocketops
   class Config
     attr_reader :settings,
@@ -39,7 +41,7 @@ module Pocketops
     def generate_user_password
       dict = [(0..9), ('a'..'z'), ('A'..'Z')].map(&:to_a).flatten
       @password = (1..15).map { dict.sample }.join
-      @ansible_vars['password'] = password.crypt("$6$#{rand}$")
+      @ansible_vars['password'] = UnixCrypt::SHA512.build(@password, rand.to_s[0..15])
       @password
     end
 

--- a/pocketops.gemspec
+++ b/pocketops.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor"
+  spec.add_runtime_dependency "unix-crypt"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
This change makes `pops init` work on OS X machines.

_Details:_
- Debian/Ubuntu uses SHA512-encrypted passwords.
- The gem tries to build these in Ruby using `String#crypt`.
- OS X doesn't support the correct SHA512 encryption using native `String#crypt`.
- A Ruby gem without external dependencies can be used to recreate that functionality.
- This new approach is cross-platform and should work on any machine.
